### PR TITLE
Allow Selecting an Xcode Version on Self-Hosted Runners

### DIFF
--- a/.github/workflows/xcodebuild-or-fastlane.yml
+++ b/.github/workflows/xcodebuild-or-fastlane.yml
@@ -108,7 +108,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
-      if: "!env.selfhosted"
       with:
         xcode-version: ${{ inputs.xcodeversion }}
     - name: Check environment


### PR DESCRIPTION
# Allow Selecting an Xcode Version on Self-Hosted Runners

## :recycle: Current situation & Problem
- Selecting Xcode has previously only been allowed for GitHub runners due to failing permissions on self-hosted runners.

## :bulb: Proposed solution
- Fixes this setup by using a new version of a runner image (https://github.com/StanfordBDHG/ContinousIntegration) that allows switching Xcode versions without sudo permissions.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
